### PR TITLE
Fix return Promises so each step runs in sequence

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,11 +31,11 @@ function loadMacros(context) {
         series.add(() => {
           // support objects so that we can pass arguments from user settings to the commands
           if (typeof action === "object"){
-            vscode.commands.executeCommand(action.command, action.args);
+            return vscode.commands.executeCommand(action.command, action.args);
           }
           // support commands as strings (no args)
           else{
-            vscode.commands.executeCommand(action);
+            return vscode.commands.executeCommand(action);
           }
         })
       })


### PR DESCRIPTION
Return the Promise of each executeCommand() call to PromiseSeries, so that commands are executed in sequence, not in parallel.